### PR TITLE
Remove combination address   confidence match

### DIFF
--- a/cs_connectv1-15.json
+++ b/cs_connectv1-15.json
@@ -5801,7 +5801,7 @@
             }
           },           
           "401": {
-            "description": "",
+            "description": "Invalid Token",
             "content": {
               "application/json": {
                 "schema": {
@@ -5811,7 +5811,7 @@
             }
       },
     "403": {
-        "description": "",
+        "description": "Access Forbidden",
         "content": {
           "application/json": {
             "schema": {

--- a/cs_connectv1-15.json
+++ b/cs_connectv1-15.json
@@ -5799,9 +5799,42 @@
                 }
               }
             }
+          },           
+          "401": {
+            "description": "",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Connect.ErrorResponses.InvalidToken"
+                }
+              }
+            }
+      },
+    "403": {
+        "description": "",
+        "content": {
+          "application/json": {
+            "schema": {
+              "type": "object",
+              "example": {
+                "message": "Access forbidden"
+              }
+            }
           }
         }
       },
+    "500": {
+        "description": "Server Error",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Connect.Identity.BasicResponse"
+            }
+          }
+        }
+      }
+    }
+  },
       "put": {
         "tags": [
           "GB Consumers and AML"

--- a/cs_connectv1-15.json
+++ b/cs_connectv1-15.json
@@ -635,15 +635,6 @@
             }
           },
           {
-            "name": "address",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "nullable": true
-            },
-            "description": "Combination of all address fields to form a simpleValue address string."
-          },
-          {
             "name": "street",
             "in": "query",
             "description": "Address part identifier - Street of the Company",
@@ -9985,11 +9976,11 @@
       "Creditsafe.GlobalData.CompanyData": {
         "type": "object",
         "properties": {
-          "country": {
-            "$ref": "#/components/schemas/Creditsafe.GlobalData.CountryCode"
-          },
           "id": {
             "type": "string"
+          },
+          "country": {
+            "$ref": "#/components/schemas/Creditsafe.GlobalData.CountryCode"
           },
           "safeNo": {
             "type": "string"


### PR DESCRIPTION
Removal of combination address from Companies - match - to improve match score

Additional error responses added to GB Consumer and AML 

Re-ordered some of company report JSON response to match actual API response